### PR TITLE
fix: update healthcheck endpoint in check_vllm_healthcheck function

### DIFF
--- a/docext/app/utils.py
+++ b/docext/app/utils.py
@@ -12,7 +12,7 @@ def cleanup(signum, frame, vllm_server):
 
 def check_vllm_healthcheck(host: str, port: int):
     try:
-        response = requests.get(f"http://{host}:{port}/healthcheck")
+        response = requests.get(f"http://{host}:{port}/health")
         return response.status_code == 200
     except Exception as e:
         return False


### PR DESCRIPTION
# Fix health check endpoint for vLLM compatibility

I encountered a recurring error when running the web interface while using vLLM (docker image vllm/vllm-openai:0.8.5) as the backend server, even though vLLM was serving correctly.

Upon investigation, I found that the health check endpoint was set to `/healthcheck`, but vLLM actually uses `/health`. After updating the endpoint on `doctext/app/utils.py` to match vLLM's expected endpoint, the web interface started working properly.

This change ensures compatibility with vLLM's standard health check endpoint.
![Screenshot from 2025-06-17 12-42-34](https://github.com/user-attachments/assets/cab58c8e-a829-4404-a2b3-12dcd6eda5b3)


