### PR TITLE
Fix: Add transformers version constraints to resolve TypeError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Gradio related files
+.gradio/

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ loguru
 mdpd
 numpy
 pandas
+pdf2image
 PyMuPDF
 python-dotenv
 python-levenshtein==0.27.1
@@ -13,7 +14,7 @@ requests
 setuptools
 tabulate
 tenacity
+transformers>=4.51.1,<4.53.0
 types-requests
-vllm==v0.8.3
+vllm==0.8.3
 xgrammar==0.1.17
-pdf2image


### PR DESCRIPTION
# Problem
When attempting to run docext on a machine with a pre-existing or incompatible version of transformers, a conflict arises due to version mismatches. This leads to runtime errors that prevent the module from executing correctly.

## Related Issue
Closes #46 

## Specific Error
```TypeError: Qwen2_5_VLProcessor.init() got multiple values for argument 'image_processor'```
This error is typically caused by incompatibilities between the transformers version and the expected function signature used by vLLM.

# Solution
Pin the appropriate transformers version in the requirements.txt file to ensure compatibility with the vLLM version used in the project. This prevents unexpected behavior and ensures consistent runtime across environments. 